### PR TITLE
Add timeout to raw_bg read, avoid hang on certain platforms

### DIFF
--- a/grep+
+++ b/grep+
@@ -998,7 +998,7 @@ terminal_color() {
 	echo -en "\033]${style_code};?\033\\" > /dev/tty
 	
 	# shellcheck disable=SC1003
-	if IFS=';' read -r -d '\' raw_bg; then
+	if IFS=';' read -r -t 1 -d '\' raw_bg; then
 		bg=$(echo "$raw_bg" | sed 's/^.*\;//;s/[^rgb:0-9a-f/]//g')
 		bg=${bg#*:}
 		


### PR DESCRIPTION
First you are a crazy mad person with far too much love for bash;)

Second, this script works on linux (ubuntu) and windows (msys but native windows highlight.exe) but I ran into an issue.

https://github.com/misaki-web/grepp/blob/cfc8148e2b18a64639740dfdfa1508120e19b1ba/grep%2B#L1001

this command that looks like its trying to read the background color from the terminal hangs on both platforms for me.

As I am not nearly as smart as you however, I can't figure out exactly how it should work to actually fix it.  Instead here is a quick 1 second timeout to prevent the hang for those of us who don't have the slash incoming.

